### PR TITLE
add import statement for stats functions

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
+importFrom("stats", "dnorm", "pnorm", "qnorm", "runif")
 export( dmp, pmp, qmp, rmp,
         dtw, ptw, qtw, rtw, 
      	dWishartMax, pWishartMax, qWishartMax, rWishartMax,


### PR DESCRIPTION
This (small) PR addresses the CRAN notes that can be found here: https://cran.r-project.org/web/checks/check_results_RMTstat.html

I'm the maintainer for the packages `covequal` and `pcev`, which both depend on `RMTstat`. I recently received an email from CRAN that `RMTstat` is scheduled to be archived on April 18th, and both my packages will also be archived unless I remove the dependency. `RMTstat` has other reverse dependencies whose maintainers have similarly been advised.

The simplest solution is to submit a new version of `RMTstat` that passes all the checks on CRAN, so that no package is archived. I looked at the issues that triggered the archival process, and they are quite minor. This pull-request should fix these issues (although I only ran the checks locally). You'll have to increase the version number before submitting, and you may want to change the email address of the maintainer if it's no longer current. In their email to me, CRAN said the email they sent to the maintainer bounced.

Let me know if I can help in any other way.